### PR TITLE
Support Python 3.13 and 3.14 (drop 3.9, 3.10, 3.11) and upgrade pywin32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,9 @@ build-backend = "hatchling.build"
 name = "windowsservice"
 description = "A Python package for building Windows services."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 license = "MIT"
-authors = [
-    { name = "Hylke Postma", email = "info@hylkepostma.nl" },
-]
+authors = [{ name = "Hylke Postma", email = "info@hylkepostma.nl" }]
 keywords = [
     "multiprocessing",
     "pyinstaller",
@@ -25,28 +23,19 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Build Tools",
 ]
-dependencies = [
-    "pywin32==306",
-]
+dependencies = ["pywin32==311"]
 dynamic = ["version"]
 
 [tool.hatch.version]
 path = "src/windowsservice/__about__.py"
 
 [project.optional-dependencies]
-test = [
-    "pytest >=7.2.0,<8.0.0",
-    "pyinstaller >=6.5.0, <7"
-]
-dev = [
-    "ruff",
-    "black",
-]
+test = ["pytest >=7.2.0,<10.0.0", "pyinstaller >=6.5.0, <7"]
+dev = ["ruff", "black"]
 all = ["windowsservice[test, dev]"]
 
 [project.urls]


### PR DESCRIPTION
**Python compatibility and dependency updates:**

* Increased the minimum required Python version from `>=3.9` to `>=3.13`, and updated the supported Python classifiers to include Python 3.13 and 3.14, removing older versions.
* Updated the `pywin32` dependency from version `306` to `311` to ensure compatibility with newer Python versions.